### PR TITLE
fix: allow 2 or more spaces after type

### DIFF
--- a/lang-config/syntaxes/ros2.interface.json
+++ b/lang-config/syntaxes/ros2.interface.json
@@ -4,7 +4,7 @@
     "patterns": [
         {
             "name": "meta.field.ros2.interface",
-            "begin": "^\\b([a-zA-Z][(<=)/a-z_A-Z0-9]*)(\\[[<=\\d]*\\])?\\s(\\w+)",
+            "begin": "^\\b([a-zA-Z][(<=)/a-z_A-Z0-9]*)(\\[[<=\\d]*\\])?\\s+(\\w+)",
             "end": "$",
             "beginCaptures": {
                 "1": {


### PR DESCRIPTION
The previous syntax highlighting cannot handle 2 or more spaces after a
type description so this fixes it.